### PR TITLE
Fixed PHP7 Warning (max(): Array must contain at least one element)

### DIFF
--- a/includes/caching.class.php
+++ b/includes/caching.class.php
@@ -48,8 +48,11 @@ public function add_hook()
 
 public function nonce_life($life)
 {
-    $expires = get_option("nginxchampuru-cache_expires", array($life));
-    $max = max(array_values($expires));
+    $expires = get_option(NginxChampuru::OPTION_NAME_CACHE_EXPIRES, array($life));
+    $max =
+        is_array($expires) && is_array(array_values($expires))
+        ? max(array_values($expires))
+        : 0;
     if ($max > $life) {
         return $max;
     } else {


### PR DESCRIPTION
PHP7 環境で、Expires オプションを設定していない場合に以下のような Warning がでます。

```
PHP Warning:  max(): Array must contain at least one element in /var/www/html/wp-content/plugins/nginx-champuru/includes/caching.class.php on line 52
```

これは、それを修正するためのパッチです。